### PR TITLE
Fix GitHub ribbon for plugins using this as parent pom

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -45,7 +45,7 @@
         <widget>thin-badge</widget>
       </ohloh>
       <gitHub>
-        <projectId>mojohaus/${this.artifactId}</projectId>
+        <projectId>mojohaus/${project.artifactId}</projectId>
         <ribbonOrientation>right</ribbonOrientation>
         <ribbonColor>gray</ribbonColor>
       </gitHub>


### PR DESCRIPTION
Currently this ribbon always links to the mojo-parent GitHub project.