### PR TITLE
Maven Surefire and Failsafe plugins v2.22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>2.22.2</version>
           <configuration>
             <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
           </configuration>
@@ -440,12 +440,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>2.22.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-report-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>2.22.2</version>
         </plugin>
         <!-- Codehaus plugins in alphabetical order -->
         <plugin>
@@ -808,7 +808,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-report-plugin</artifactId>
-            <version>2.19.1</version>
+            <version>2.22.2</version>
             <reportSets>
               <reportSet>
                 <reports>


### PR DESCRIPTION
Wanting to update versions-maven-plugin to use junit-jupiter v5.6.0, but having issues with mocking with v2.19.1, I tried v2.22.2 and it works fine.

Once approved, merged and released it will allow https://github.com/mojohaus/versions-maven-plugin/pull/385 to be changed from SNAPSHOT version and pass pre merge builds.