### PR TITLE
#210 Configure release drafter for single version numbers used by mojo-parent

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,9 @@
 _extends: .github
-tag-template: mojo-parent-$NEXT_MINOR_VERSION
+# mojo-parent uses a single version number, no semantic versioning
+version-template: '$MAJOR'
+name-template: '$NEXT_MAJOR_VERSION'
+tag-template: 'mojo-parent-$NEXT_MAJOR_VERSION'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
it's also useful to be able to start the workflow manually when tags are added/updated after the last run

Fixes #210