### PR TITLE
Improvement checkstyle configuration

### DIFF
--- a/config-assembly.xml
+++ b/config-assembly.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.1 http://maven.apache.org/xsd/assembly-2.1.1.xsd">
+
+  <id>config</id>
+
+  <formats>
+    <format>jar</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <fileSets>
+    <fileSet>
+      <directory>src/main/config</directory>
+      <outputDirectory>mojohaus/config</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -305,14 +305,36 @@
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${maven-checkstyle-plugin.version}</version>
           <configuration>
+            <sourceDirectories>
+              <sourceDirectory>src/main/java</sourceDirectory>
+            </sourceDirectories>
+            <testSourceDirectories>
+              <testSourceDirectory>src/test/java</testSourceDirectory>
+            </testSourceDirectories>
+            <includeTestSourceDirectory>true</includeTestSourceDirectory>
             <configLocation>config/maven_checks.xml</configLocation>
-            <headerLocation>config/maven-header.txt</headerLocation>
+            <!-- by default don't check headers -->
+            <headerLocation>mojohaus/config/checkstyle/empty-header.txt</headerLocation>
           </configuration>
+          <executions>
+            <execution>
+              <phase>validate</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.shared</groupId>
               <artifactId>maven-shared-resources</artifactId>
               <version>4</version>
+            </dependency>
+            <dependency>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>mojo-parent</artifactId>
+              <version>70-SNAPSHOT</version>
+              <classifier>config</classifier>
             </dependency>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
@@ -525,16 +547,8 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
-      <!--
-        We need to define the invocation of the plugin here because
-        Maven does not pickup the dependencies of checkstyle during
-        run of `mvn site` otherwise, see #23.
-      -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -606,6 +620,24 @@
             <id>attach-descriptor</id>
             <goals>
               <goal>attach-descriptor</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <inherited>false</inherited>
+        <configuration>
+          <descriptors>
+            <descriptor>config-assembly.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
             </goals>
           </execution>
         </executions>
@@ -737,10 +769,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
             <version>${maven-checkstyle-plugin.version}</version>
-            <configuration>
-              <configLocation>config/maven_checks.xml</configLocation>
-              <headerLocation>config/maven-header.txt</headerLocation>
-            </configuration>
             <reportSets>
               <reportSet>
                 <reports>

--- a/src/main/config/checkstyle/asf20-header.txt
+++ b/src/main/config/checkstyle/asf20-header.txt
@@ -1,0 +1,17 @@
+^package
+
+^/\*$
+^ \* Copyright
+^ \*$
+^ \* Licensed under the Apache License, Version 2.0 \(the "License"\);$
+^ \* you may not use this file except in compliance with the License.$
+^ \* You may obtain a copy of the License at$
+^ \*$
+^ \*     https?://www.apache.org/licenses/LICENSE-2.0$
+^ \*$
+^ \*  Unless required by applicable law or agreed to in writing, software$
+^ \*  distributed under the License is distributed on an "AS IS" BASIS,$
+^ \*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.$
+^ \*  See the License for the specific language governing permissions and$
+^ \*  limitations under the License.$
+^ \*/$

--- a/src/main/config/checkstyle/mit-header.txt
+++ b/src/main/config/checkstyle/mit-header.txt
@@ -1,0 +1,25 @@
+^package
+
+^/\*$
+^ \* The MIT License$
+^ \*$
+^ \* Copyright
+^ \*$
+^ \* Permission is hereby granted, free of charge, to any person obtaining a copy of$
+^ \* this software and associated documentation files (the "Software"), to deal in$
+^ \* the Software without restriction, including without limitation the rights to$
+^ \* use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies$
+^ \* of the Software, and to permit persons to whom the Software is furnished to do$
+^ \* so, subject to the following conditions:$
+^ \*$
+^ \* The above copyright notice and this permission notice shall be included in all$
+^ \* copies or substantial portions of the Software.$
+^ \*$
+^ \* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR$
+^ \* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,$
+^ \* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE$
+^ \* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER$
+^ \* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,$
+^ \* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE$
+^ \* SOFTWARE.
+^ \*/$


### PR DESCRIPTION
- by default don't check herders for licences
- provide headers template for ASF 2.0 and MIT