### PR TITLE
Use only project version as tag for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,6 +443,7 @@
             <goals>deploy</goals>
             <arguments>-Pmojo-release</arguments>
             <autoVersionSubmodules>true</autoVersionSubmodules>
+            <tagNameFormat>@{project.version}</tagNameFormat>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Default value for m-release-p is `@{project.artifactId}-@{project.version}`

Nowadays we use separate git repositories for each project so release tag can be simplified

