### PR TITLE
Remove SHA-512 checksum for source release artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -710,34 +710,6 @@
               </execution>
             </executions>
           </plugin>
-          <!-- calculate checksums of source release for Apache dist area -->
-          <plugin>
-            <groupId>net.nicoulaj.maven.plugins</groupId>
-            <artifactId>checksum-maven-plugin</artifactId>
-            <version>1.11</version>
-            <executions>
-              <execution>
-                <id>source-release-checksum</id>
-                <goals>
-                  <goal>artifacts</goal>
-                </goals>
-                <!-- execute prior to maven-gpg-plugin:sign due to https://github.com/nicoulaj/checksum-maven-plugin/issues/112 -->
-                <phase>post-integration-test</phase>
-                <configuration>
-                  <algorithms>
-                    <algorithm>SHA-512</algorithm>
-                  </algorithms>
-                  <!-- https://maven.apache.org/apache-resource-bundles/#source-release-assembly-descriptor -->
-                  <includeClassifiers>source-release</includeClassifiers>
-                  <excludeMainArtifact>true</excludeMainArtifact>
-                  <csvSummary>false</csvSummary>
-                  <!-- attach SHA-512 checksum as well to upload to Maven Staging Repo,
-                       as this eases uploading from stage to dist and doesn't do harm in Maven Central -->
-                  <attachChecksums>true</attachChecksums>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
It is needed only by ASF distribution projects