### PR TITLE
Remove Checkstyle from reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -748,18 +748,6 @@
           <!-- Apache plugins in alphabetical order -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>${maven-checkstyle-plugin.version}</version>
-            <reportSets>
-              <reportSet>
-                <reports>
-                  <report>checkstyle</report>
-                </reports>
-              </reportSet>
-            </reportSets>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>${maven-javadoc-plugin.version}</version>
             <reportSets>


### PR DESCRIPTION
Checkstyle can be used during build in order to detect issues.

Report from release time has no valuable information - actual code may change many times.