### PR TITLE
Remove jxr from reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -775,11 +775,6 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-jxr-plugin</artifactId>
-            <version>${maven-jxr-plugin.version}</version>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-plugin-report-plugin</artifactId>
           </plugin>
           <plugin>


### PR DESCRIPTION
Will not be needed after removing other reporting plugins.