### PR TITLE
Introduce enforcer rule for minimal version of Java and Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,10 @@
     <mojo.java.target>1.8</mojo.java.target>
     <maven.compiler.source>${mojo.java.target}</maven.compiler.source>
     <maven.compiler.target>${mojo.java.target}</maven.compiler.target>
+
+    <minimalJavaBuildVersion>${mojo.java.target}</minimalJavaBuildVersion>
+    <minimalMavenBuildVersion>3.2.5</minimalMavenBuildVersion>
+
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- NOTE: We deliberately do not set maven.test.redirectTestOutputToFile here to workaround MNG-1992 -->
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
@@ -606,9 +610,12 @@
                   <banRelease>true</banRelease>
                 </requirePluginVersions>
                 <requireMavenVersion>
-                  <version>3.2.5</version>
-                  <message>You need at least Maven 3.2.5 to build MojoHaus projects.</message>
+                  <version>${minimalMavenBuildVersion}</version>
+                  <message>You need at least Maven ${minimalMavenBuildVersion} to build MojoHaus projects.</message>
                 </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>${minimalJavaBuildVersion}</version>
+                </requireJavaVersion>
                 <requireProperty>
                   <property>project.scm.connection</property>
                   <!-- because Maven adds the artifactId to the SCM-Url automatically for modules in a multimodule project,


### PR DESCRIPTION
Minimal Maven version check is already in place,
only add property `minimalMavenBuildVersion`

New check and property for minimal Java version
`minimalJavaBuildVersion` by default equal to `mojo.java.target`