### PR TITLE
Add maven-wrapper-plugin to pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,8 @@
     <maven-surefire-plugin.version>3.0.0-M8</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>3.0.0-M8</maven-surefire-report-plugin.version>
     <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
+    <maven-wrapper-plugin.version>3.1.1</maven-wrapper-plugin.version>
+
     <mrm-maven-plugin.version>1.4.1</mrm-maven-plugin.version>
     <modello-maven-plugin.version>2.0.0</modello-maven-plugin.version>
     <plexus-component-metadata.version>2.1.1</plexus-component-metadata.version>
@@ -519,6 +521,12 @@
           <artifactId>maven-surefire-report-plugin</artifactId>
           <version>${maven-surefire-report-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-wrapper-plugin</artifactId>
+          <version>${maven-wrapper-plugin.version}</version>
+        </plugin>
+
         <!-- Codehaus plugins in alphabetical order -->
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Maven 4 has wrapper lifecycle, so we need provide a version to pass RequirePluginVersions enforce rule.