### PR TITLE
Remove ossrh-snapshots repository from MojoHaus parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,22 +278,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <repositories>
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <checksumPolicy>fail</checksumPolicy>
-      </snapshots>
-      <id>ossrh-snapshots</id>
-      <name>ossrh-snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <layout>default</layout>
-    </repository>
-  </repositories>
-
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
Snapshots repositories should be only used for testing purpose, 
when some project needs it, it can be added for testing time in specific project