### PR TITLE
Rename property maven.version to mavenVersion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,8 +197,8 @@
     <minimalJavaBuildVersion>${mojo.java.target}</minimalJavaBuildVersion>
     <recommendedJavaBuildVersion>${minimalJavaBuildVersion}</recommendedJavaBuildVersion>
 
-    <maven.version>3.2.5</maven.version>
-    <minimalMavenBuildVersion>${maven.version}</minimalMavenBuildVersion>
+    <mavenVersion>3.2.5</mavenVersion>
+    <minimalMavenBuildVersion>${mavenVersion}</minimalMavenBuildVersion>
 
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- NOTE: We deliberately do not set maven.test.redirectTestOutputToFile here to workaround MNG-1992 -->
@@ -266,7 +266,7 @@
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
         <!-- Minimum required Maven Version -->
-        <version>${maven.version}</version>
+        <version>${mavenVersion}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
maven.version is used internally by Maven,
so should be not used in project

Property was introduced in version 73 - 1e5139c3b7cd9304df7dc865b818cdc563b38d8e