### PR TITLE
Drop recommendedJavaBuildVersion property

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,0 @@
--DrecommendedJavaBuildVersion=11

--- a/pom.xml
+++ b/pom.xml
@@ -179,8 +179,6 @@
     <maven.compiler.target>${mojo.java.target}</maven.compiler.target>
 
     <minimalJavaBuildVersion>${mojo.java.target}</minimalJavaBuildVersion>
-    <recommendedJavaBuildVersion>${minimalJavaBuildVersion}</recommendedJavaBuildVersion>
-
     <minimalMavenBuildVersion>3.6.3</minimalMavenBuildVersion>
     <mavenVersion>${minimalMavenBuildVersion}</mavenVersion>
 
@@ -655,11 +653,6 @@
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>${minimalJavaBuildVersion}</version>
-                </requireJavaVersion>
-                <requireJavaVersion>
-                  <version>${recommendedJavaBuildVersion}</version>
-                  <level>WARN</level>
-                  <message>Recommended Java version for build should be at least ${recommendedJavaBuildVersion}</message>
                 </requireJavaVersion>
                 <requireProperty>
                   <property>project.scm.connection</property>


### PR DESCRIPTION
Since we use spotless for all JDK it is not needed - next simplification