### PR TITLE
Fix spotless configuration for markdown - exclude generated files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -600,6 +600,9 @@
               <includes>
                 <include>**/*.md</include>
               </includes>
+              <excludes>
+                <excludes>target/**</excludes>
+              </excludes>
               <flexmark />
             </markdown>
             <upToDateChecking>


### PR DESCRIPTION
fix #504