### PR TITLE
Use specific report for maven-plugin-report-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -881,6 +881,13 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-plugin-report-plugin</artifactId>
+            <reportSets>
+              <reportSet>
+                <reports>
+                  <report>report</report>
+                </reports>
+              </reportSet>
+            </reportSets>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
maven-plugin-report-plugin since 3.14.0 contains two reports so we need to specific which one we want to use