### PR TITLE
Remove banner name from site descriptor

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -19,8 +19,8 @@
 <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
 
-  <bannerLeft name="MojoHaus" href="https://www.mojohaus.org/">
-    <image src="https://www.mojohaus.org/images/mojo_logo.png" />
+  <bannerLeft href="https://www.mojohaus.org/">
+    <image src="https://www.mojohaus.org/images/mojo_logo.png" alt="MojoHaus" />
   </bannerLeft>
 
   <publishDate position="right" />


### PR DESCRIPTION
In old version of skin banner.name was used as image alt

Now banner.name is always print - remove it to make site looks the same as current.