### PR TITLE
Enable njord only in the release profile and auto publish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 
     <minimalJavaBuildVersion>${mojo.java.target}</minimalJavaBuildVersion>
-    <minimalMavenBuildVersion>3.9.0</minimalMavenBuildVersion>
+    <minimalMavenBuildVersion>${mavenVersion}</minimalMavenBuildVersion>
     <mavenVersion>3.6.3</mavenVersion>
 
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -225,7 +225,6 @@
     <maven-surefire-report-plugin.version>3.5.3</maven-surefire-report-plugin.version>
     <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
     <maven-wrapper-plugin.version>3.3.2</maven-wrapper-plugin.version>
-    <njord.autoPublish>true</njord.autoPublish>
     <njord.version>0.7.1</njord.version>
     <mrm-maven-plugin.version>1.6.0</mrm-maven-plugin.version>
     <modello-maven-plugin.version>2.5.0</modello-maven-plugin.version>
@@ -244,6 +243,12 @@
     <checkstyle.config.location>config/maven_checks_nocodestyle.xml</checkstyle.config.location>
 
     <invoker.streamLogsOnFailures>true</invoker.streamLogsOnFailures>
+
+    <!-- njord configuration -->
+    <njord.autoPublish>true</njord.autoPublish>
+    <jord.publishingType>automatic</jord.publishingType>
+    <njord.waitForStates>true</njord.waitForStates>
+    <njord.enabled>false</njord.enabled>
   </properties>
 
   <dependencyManagement>
@@ -792,6 +797,8 @@
         <!-- due to m-deploy-p 3.x we need use Maven 3.9.x at least -->
         <!-- https://issues.apache.org/jira/browse/MNG-7055 -->
         <minimalMavenBuildVersion>3.9.0</minimalMavenBuildVersion>
+        <!-- use njord during release -->
+        <njord.enabled>true</njord.enabled>
       </properties>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
 
     <!-- njord configuration -->
     <njord.autoPublish>true</njord.autoPublish>
-    <jord.publishingType>automatic</jord.publishingType>
+    <njord.publishingType>automatic</njord.publishingType>
     <njord.waitForStates>true</njord.waitForStates>
     <njord.enabled>false</njord.enabled>
   </properties>


### PR DESCRIPTION
This will allow us to execute tests on an older Maven version