### PR TITLE
Use spotless / palantirJavaFormat - 2.56.0 for all JDKs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,7 @@
     <mojo.java.target>8</mojo.java.target>
     <maven.compiler.source>${mojo.java.target}</maven.compiler.source>
     <maven.compiler.target>${mojo.java.target}</maven.compiler.target>
+    <maven.compiler.release>${mojo.java.target}</maven.compiler.release>
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 
     <minimalJavaBuildVersion>${mojo.java.target}</minimalJavaBuildVersion>
@@ -235,6 +236,8 @@
     <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
     <sisu-maven-plugin.version>0.9.0.M4</sisu-maven-plugin.version>
     <spotless-maven-plugin.version>2.44.5</spotless-maven-plugin.version>
+    <!-- we use version 2.56.0 due to: https://github.com/palantir/palantir-java-format/issues/1320 -->
+    <palantirJavaFormat.version>2.56.0</palantirJavaFormat.version>
     <project.build.outputTimestamp>2025-06-02T19:00:39Z</project.build.outputTimestamp>
     <!-- mono-module doesn't require site:stage for scm-publish -->
     <scmpublish.content>${project.reporting.outputDirectory}</scmpublish.content>
@@ -610,7 +613,11 @@
             <java>
               <!-- orders of used formatters are important -->
               <!-- eg. palantir override importOrder, so should be first -->
-              <palantirJavaFormat />
+              <palantirJavaFormat>
+                <!-- Declare version so that spotless does not choose a version based on JDK version -->
+                <!-- https://github.com/diffplug/spotless/issues/2503#issuecomment-2953146277 -->
+                <version>${palantirJavaFormat.version}</version>
+              </palantirJavaFormat>
               <removeUnusedImports />
               <importOrder>
                 <order>javax,java,,\#</order>
@@ -712,19 +719,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>spotless-check</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>validate</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <inherited>false</inherited>
@@ -774,23 +768,20 @@
 
   <profiles>
     <profile>
-      <id>jdk8</id>
-      <activation>
-        <jdk>[1.8,11)</jdk>
-      </activation>
-      <properties>
-        <!-- last version working with java 8 -->
-        <spotless-maven-plugin.version>2.30.0</spotless-maven-plugin.version>
-      </properties>
-    </profile>
-    <profile>
       <id>java11+</id>
       <activation>
-        <jdk>[11,)</jdk>
+        <!-- TODO check support for JDK 25 after palantirJavaFormat upgraded -->
+        <jdk>[11,25)</jdk>
       </activation>
-      <properties>
-        <maven.compiler.release>${mojo.java.target}</maven.compiler.release>
-      </properties>
+      <build>
+        <!--- newer versions of plugins requires JDK 11 -->
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>


### PR DESCRIPTION
Spotless start using palantir-java-format 2.57.0 on Java 21 - on older jdks different versions are used.

It causes a different code format depends on using JDK

references:
 - https://github.com/diffplug/spotless/pull/2447
 - https://github.com/diffplug/spotless/issues/2503
 - https://github.com/palantir/palantir-java-format/issues/1320

Additionally, we can't use older spotless on JDK8

As issue - https://github.com/diffplug/spotless/issues/2503 was closed, reverting spotless plugin to older version is not a resoultion.